### PR TITLE
remove global variable

### DIFF
--- a/jquery.easyListSplitter.js
+++ b/jquery.easyListSplitter.js
@@ -22,9 +22,11 @@
 	
  */
 
-var j = 1;
+
  
 (function(jQuery) {
+	var j = 1;
+	
 	jQuery.fn.easyListSplitter = function(options) {
 	
 	var defaults = {			


### PR DESCRIPTION
A plugin should not depend upon global variables, as they can be modified by any other code on the page. We in fact just got bitten by this, as another third-party script also uses a global variable called `j` and sets it to a script tag, which breaks this plugin.

I've changed it so that `j` is now local, and thus cannot be changed by external code.
